### PR TITLE
Fix EPD display initialization and restore original port

### DIFF
--- a/shared.py
+++ b/shared.py
@@ -218,41 +218,16 @@ class SharedData:
         self.generate_actions_json()
         self.delete_webconsolelog()
         self.initialize_csv()
-        # self.initialize_epd_display()  # Temporarily disabled for testing
+        self.initialize_epd_display()
     
 
-    # def initialize_epd_display(self):
-    #     """Initialize the e-paper display."""
-    #     try:
-    #         logger.info("Initializing EPD display...")
-    #         time.sleep(1)
-    #         self.epd_helper = EPDHelper(self.config["epd_type"])
-    #         self.epd_helper = EPDHelper(self.epd_type)
-    #         if self.config["epd_type"] == "epd2in13_V2":
-    #             logger.info("EPD type: epd2in13_V2 screen reversed")
-    #             self.screen_reversed = False
-    #             self.web_screen_reversed = False
-    #         elif self.config["epd_type"] == "epd2in13_V3":
-    #             logger.info("EPD type: epd2in13_V3 screen reversed")
-    #             self.screen_reversed = False
-    #             self.web_screen_reversed = False
-    #         elif self.config["epd_type"] == "epd2in13_V4":
-    #             logger.info("EPD type: epd2in13_V4 screen reversed")
-    #             self.screen_reversed = True
-    #             self.web_screen_reversed = True
-    #         self.epd_helper.init_full_update()
-    #         self.width, self.height = self.epd_helper.epd.width, self.epd_helper.epd.height
-    #         logger.info(f"EPD {self.config['epd_type']} initialized with size: {self.width}x{self.height}")
-    #     except Exception as e:
-    #         logger.error(f"Error initializing EPD display: {e}")
-    #         raise
+
     def initialize_epd_display(self):
         """Initialize the e-paper display."""
         try:
             logger.info("Initializing EPD display...")
             time.sleep(1)
             self.epd_helper = EPDHelper(self.config["epd_type"])
-            self.epd_helper = EPDHelper(self.epd_type)
             if self.config["epd_type"] == "epd2in7":
                 logger.info("EPD type: epd2in7 screen reversed")
                 self.screen_reversed = False

--- a/webapp.py
+++ b/webapp.py
@@ -215,7 +215,7 @@ def handle_exit_web(signum, frame):
     sys.exit(0)
 
 # Initialize the web thread
-web_thread = WebThread(port=12000)
+web_thread = WebThread(port=8000)
 
 # Set up signal handling for graceful shutdown
 signal.signal(signal.SIGINT, handle_exit_web)


### PR DESCRIPTION
- Restored EPD display initialization in setup_environment()
- Fixed missing screen_reversed attribute that was causing crashes
- Removed duplicate EPDHelper initialization line
- Restored webapp port from 12000 back to 8000 for production compatibility
- Cleaned up commented code blocks

This fixes the service crash while maintaining WiFi functionality improvements.