### PR TITLE
Fix KeyError in orchestrator.py: add check for action_key existence i…

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -135,6 +135,10 @@ class Orchestrator:
             if 'success' not in parent_status:
                 return False  # Skip child action if parent action has not succeeded
 
+        # Ensure action_key exists in row
+        if action_key not in row:
+            row[action_key] = ""
+
         # Check if the action is already successful and if retries are disabled for successful actions
         if 'success' in row[action_key]:
             if not self.shared_data.retry_success_actions:


### PR DESCRIPTION
…n row

- Add safety check to ensure action_key exists in row before accessing it
- Prevents KeyError when action_key (like 'SSHBruteforce') is missing from row data
- Initialize missing action_key with empty string to maintain consistency